### PR TITLE
fix: move @types/react* to dependencies

### DIFF
--- a/template/frontend/package.json
+++ b/template/frontend/package.json
@@ -12,8 +12,6 @@
     "watch": "run-p watch:*"
   },
   "devDependencies": {
-    "@types/react": "^16.9.2",
-    "@types/react-dom": "^16.9.0",
     "@types/webpack": "^4.39.1",
     "@typescript-eslint/eslint-plugin": "^2.0.0",
     "@typescript-eslint/parser": "^2.0.0",
@@ -31,6 +29,8 @@
     "webpack-dev-server": "^3.8.0"
   },
   "dependencies": {
+    "@types/react": "^16.9.2",
+    "@types/react-dom": "^16.9.0",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "sanitize.css": "^11.0.0"


### PR DESCRIPTION
Move following packages to dependencies.

- `@types/react`
- `@types/react-dom`