### PR TITLE
chore: remove .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,0 @@
-!.eslintrc.js
-!.prettierrc.js
-node_modules/
-lib/
-template/

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,14 +1,17 @@
 module.exports = {
   env: {
+    browser: true,
     node: true,
     commonjs: true,
     es6: true,
   },
-  plugins: ["@typescript-eslint"],
+  plugins: ["@typescript-eslint", "react-hooks"],
   extends: ["eslint:recommended", "plugin:prettier/recommended"],
   rules: {
     "no-undef": "off",
     "no-unused-vars": "off",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "error",
   },
   parser: "@typescript-eslint/parser",
   parserOptions: {
@@ -17,4 +20,5 @@ module.exports = {
     },
     sourceType: "module",
   },
+  ignorePatterns: ["node_modules/", "!.eslintrc.js", "!.prettierrc.js", "lib/"],
 };

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ jobs:
         working-directory: ./template/frontend
       - name: Lint
         run: yarn lint
-      - name: Lint (template/frontend)
-        run: yarn lint
-        working-directory: ./template/frontend
       - name: Build
         run: yarn build
       - name: Test

--- a/__tests__/cli.test.ts
+++ b/__tests__/cli.test.ts
@@ -14,7 +14,6 @@ describe("create-ts-app", () => {
     ["src/index.html"],
     ["src/index.tsx"],
     [".gitignore"],
-    [".eslintignore"],
     [".eslintrc.js"],
     [".prettierrc.js"],
   ])("it should include %s", async (filename) => {
@@ -30,7 +29,7 @@ describe("create-ts-app", () => {
 
   describe("appType is frontend", () => {
     describe("ESLint is not selected", () => {
-      test.each<[string]>([[".eslintignore"], [".eslintrc.js"]])(
+      test.each<[string]>([[".eslintrc.js"]])(
         "it should not include %s",
         async (filename) => {
           const mockPromptAnswers = {
@@ -46,20 +45,19 @@ describe("create-ts-app", () => {
     });
 
     describe("ESLint and Prettier are not selected", () => {
-      test.each<[string]>([
-        [".eslintignore"],
-        [".eslintrc.js"],
-        [".prettierrc.js"],
-      ])("it should not include %s", async (filename) => {
-        const mockPromptAnswers = {
-          appType: "frontend",
-          features: [],
-          name: "test-app",
-          license: "MIT",
-        };
-        const stream = await sao.mock({ generator }, mockPromptAnswers);
-        expect(stream.fileList).not.toContain(filename);
-      });
+      test.each<[string]>([[".eslintrc.js"], [".prettierrc.js"]])(
+        "it should not include %s",
+        async (filename) => {
+          const mockPromptAnswers = {
+            appType: "frontend",
+            features: [],
+            name: "test-app",
+            license: "MIT",
+          };
+          const stream = await sao.mock({ generator }, mockPromptAnswers);
+          expect(stream.fileList).not.toContain(filename);
+        }
+      );
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -22,11 +22,7 @@
   "author": "yami-beta <yami-beta@users.noreply.github.com>",
   "license": "MIT",
   "jest": {
-    "preset": "ts-jest",
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/lib/"
-    ]
+    "preset": "ts-jest"
   },
   "scripts": {
     "lint": "eslint --ext ts,js .",
@@ -47,6 +43,7 @@
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.14.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-react-hooks": "^4.2.0",
     "jest": "^26.6.1",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.1.2",

--- a/template/frontend/.eslintignore
+++ b/template/frontend/.eslintignore
@@ -1,3 +1,0 @@
-node_modules/
-!.eslintrc.js
-!.prettierrc.js

--- a/template/frontend/.eslintrc.js
+++ b/template/frontend/.eslintrc.js
@@ -20,4 +20,5 @@ module.exports = {
     },
     sourceType: "module",
   },
+  ignorePatterns: ["node_modules/", "!.eslintrc.js", "!.prettierrc.js"],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1884,6 +1884,11 @@ eslint-plugin-prettier@^3.1.4:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-react-hooks@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"
+  integrity sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==
+
 eslint-scope@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"


### PR DESCRIPTION
.eslintignore から ignorePatterns に変更した
.eslintignore は eslint 実行時のカレントディレクトリしかみないので
プロジェクトルートと子ディレクトリで eslint を実行した時の挙動が変わってしまうため

ignorePatterns への変更に伴いプロジェクトルートの .eslintrc.js で
template 以下の Lint も実行するようにした

本当は生成後のプロジェクトでも Lint, Build が成功するかを CI に入れたいが
対話型インターフェースをスキップして生成する方法が見つからないので pending